### PR TITLE
[DOCS] Added field type and error handling

### DIFF
--- a/src/js/gutenberg/components/reference-form-manual/index.tsx
+++ b/src/js/gutenberg/components/reference-form-manual/index.tsx
@@ -148,7 +148,7 @@ function ReferenceFormManual(props: Props) {
                             onSubmit={consumeData}
                         />
                     )}
-                    <PeopleFields fields={fields[data.type].people} />
+                    <PeopleFields fields={fields[data.type]?.people} />
                     <DataFields fieldmap={fields[data.type]} />
                 </form>
             </DataContext.Provider>

--- a/src/js/utils/fieldmaps.ts
+++ b/src/js/utils/fieldmaps.ts
@@ -600,6 +600,69 @@ const CSL_FIELDS: Readonly<Record<string, FieldMapping>> = {
             },
         ],
     },
+    'journal-article': {
+        title: __('Journal Article', 'academic-bloggers-toolkit'),
+        fields: [
+            {
+                key: 'title',
+                label: __('Title', 'academic-bloggers-toolkit'),
+                inputProps: {
+                    required: true,
+                },
+            },
+            {
+                key: 'container-title',
+                label: __('Journal', 'academic-bloggers-toolkit'),
+                inputProps: {
+                    required: true,
+                },
+            },
+            {
+                key: 'journalAbbreviation',
+                label: __('Journal Abbreviation', 'academic-bloggers-toolkit'),
+            },
+            {
+                key: 'volume',
+                label: __('Volume', 'academic-bloggers-toolkit'),
+            },
+            {
+                key: 'issue',
+                label: __('Issue', 'academic-bloggers-toolkit'),
+            },
+            {
+                key: 'page',
+                label: __('Pages', 'academic-bloggers-toolkit'),
+            },
+            {
+                key: 'DOI',
+                label: __('DOI', 'academic-bloggers-toolkit'),
+            },
+            {
+                key: 'URL',
+                label: __('URL', 'academic-bloggers-toolkit'),
+            },
+            {
+                key: 'issued',
+                label: __('Date', 'academic-bloggers-toolkit'),
+                inputProps: {
+                    required: true,
+                    pattern:
+                        '[0-2][0-9]{3}(?:(\\/(?:0[1-9]|1[0-2]))(\\/(?:[0-2][0-9]|3[0-1]))?)?',
+                    title: 'YYYY/MM/DD or YYYY/MM or YYYY',
+                },
+            },
+        ],
+        people: [
+            {
+                key: 'author',
+                label: __('Author', 'academic-bloggers-toolkit'),
+            },
+            {
+                key: 'editor',
+                label: __('Editor', 'academic-bloggers-toolkit'),
+            },
+        ],
+    },
     legal_case: {
         title: __('Legal Case', 'academic-bloggers-toolkit'),
         fields: [


### PR DESCRIPTION
Recently, we faced an issue where site articles were crashing when adding DOI links.

After investigation, we found that the field type/data type being shared from DOI.org had changed, and there was a lack of error handling around the PeopleFields component.

**Changes** 
- Added support for another data type, i.e., "journal-article".
- Added error handling.